### PR TITLE
canpay: change in cors

### DIFF
--- a/src/main/java/com/canpay/api/security/ApplicationSecurityConfig.java
+++ b/src/main/java/com/canpay/api/security/ApplicationSecurityConfig.java
@@ -89,7 +89,7 @@ public class ApplicationSecurityConfig {
                 http
                                 .securityMatcher("/api/v1/**")
                                 .csrf(csrf -> csrf.disable())
-                                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+//                                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                                 .authorizeHttpRequests(auth -> auth
                                                 .requestMatchers("/api/v1/auth/**").permitAll()


### PR DESCRIPTION
This pull request includes a change to the `ApplicationSecurityConfig` class to disable the CORS configuration source for the `mobileChain` security filter chain.

Security configuration changes:

* [`src/main/java/com/canpay/api/security/ApplicationSecurityConfig.java`](diffhunk://#diff-be8dc8a7d371fcf46c3ff6deaef88f43cfa7a8df81cd30e8c2a82eb547ff2eb5L92-R92): Commented out the line that sets the CORS configuration source in the `mobileChain` method, effectively disabling it.