### PR TITLE
canpay: get all buses for specific owner

### DIFF
--- a/src/main/java/com/canpay/api/controller/account/BusControllerAc.java
+++ b/src/main/java/com/canpay/api/controller/account/BusControllerAc.java
@@ -3,19 +3,22 @@ package com.canpay.api.controller.account;
 import com.canpay.api.dto.dashboard.bus.BusRequestDto;
 import com.canpay.api.dto.dashboard.bus.BusResponseDto;
 import com.canpay.api.entity.Bus;
+import com.canpay.api.entity.ResponseEntityBuilder;
 import com.canpay.api.entity.User;
 import com.canpay.api.repository.BusRepository;
 import com.canpay.api.repository.UserRepository;
 import com.canpay.api.service.dashboard.DBusService;
+import com.canpay.api.service.implementation.JwtService;
+import com.canpay.api.service.implementation.UserServiceImpl;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -25,12 +28,16 @@ public class BusControllerAc {
     private final BusRepository busRepository;
     private final UserRepository userRepository;
     private final Logger logger = LoggerFactory.getLogger(BusControllerAc.class);
-    @Autowired
-    private   DBusService busService;
+    private final  DBusService busService;
+    private final JwtService jwtService;
+    private final UserServiceImpl userServiceImpl;
 
-    public BusControllerAc(BusRepository busRepository, UserRepository userRepository) {
+    public BusControllerAc(BusRepository busRepository, UserRepository userRepository, DBusService busService, JwtService jwtService, UserServiceImpl userServiceImpl) {
         this.busRepository = busRepository;
         this.userRepository = userRepository;
+        this.busService = busService;
+        this.jwtService = jwtService;
+        this.userServiceImpl = userServiceImpl;
     }
 
     @GetMapping("/{busId}/operator/{operatorId}")
@@ -92,4 +99,67 @@ public class BusControllerAc {
             return ResponseEntity.badRequest().build();
         }
     }
+
+    @GetMapping("/list-buses")
+    @PreAuthorize("hasRole('OWNER')")
+    public ResponseEntity<?> getAllBuses(@RequestHeader(value = "Authorization") String authHeader) {
+        logger.debug("Received request to fetch all buses");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            logger.warn("Authorization header missing or invalid");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("success", false, "message", "Authorization header with Bearer token is required"));
+        }
+
+        String token = authHeader.substring(7);
+        UUID ownerId;
+        try {
+            ownerId = jwtService.extractUserId(token);
+            String tokenRole = jwtService.extractRole(token);
+            if (!"OWNER".equals(tokenRole)) {
+                logger.warn("Invalid role in token: {}", tokenRole);
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(Map.of("success", false, "message", "Only owners can view their buses"));
+            }
+        } catch (Exception e) {
+            logger.warn("Invalid token: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("success", false, "message", "Invalid or expired token"));
+        }
+
+        if (ownerId == null) {
+            logger.warn("Owner ID is null");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("success", false, "message", "Owner ID is required"));
+        }
+
+        try {
+            // Validate owner
+            User owner = userServiceImpl.findUserById(ownerId)
+                    .orElseThrow(() -> {
+                        logger.warn("Owner not found for ID: {}", ownerId);
+                        return new RuntimeException("Owner not found");
+                    });
+            if (!User.UserRole.OWNER.equals(owner.getRole())) {
+                logger.warn("User is not an owner: {}", ownerId);
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(Map.of("success", false, "message", "User is not an owner"));
+            }
+
+            // Fetch buses for the owner
+            List<BusResponseDto> buses = busService.getBusesByOwner(ownerId);
+            logger.info("Retrieved {} buses for ownerId={}", buses.size(), ownerId);
+
+            return new ResponseEntityBuilder.Builder<Map<String, Object>>()
+                    .resultMessage("List of owner's buses retrieved successfully")
+                    .httpStatus(HttpStatus.OK)
+                    .body(Map.of("data", buses))
+                    .buildWrapped();
+        } catch (Exception e) {
+            logger.error("Failed to retrieve buses for ownerId={}: {}", ownerId, e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("success", false, "message", "Failed to retrieve buses: " + e.getMessage()));
+        }
+    }
+
 }

--- a/src/main/java/com/canpay/api/repository/bankaccount/BankAccountRepository.java
+++ b/src/main/java/com/canpay/api/repository/bankaccount/BankAccountRepository.java
@@ -10,9 +10,6 @@ import java.util.Optional;
 
 @Repository
 public interface BankAccountRepository extends JpaRepository<BankAccount, Long> {
-    List<BankAccount> findByUser(User user);
-//    Optional<BankAccount> findByUserAndDefaultTrue(User user);
-
 
     Optional<BankAccount> findByUserAndIsDefaultTrue(User user);
 }


### PR DESCRIPTION
This pull request introduces several changes to the `BusControllerAc` class and related files to improve functionality, particularly by adding a new endpoint for fetching buses associated with an owner and refactoring existing code. Additionally, modifications were made to the `BankAccountRepository` to clean up unused methods.

### Changes to `BusControllerAc`:

* **New endpoint for fetching buses by owner**:
  - Added the `getAllBuses` endpoint (`@GetMapping("/list-buses")`) to allow owners to retrieve buses associated with their account. This endpoint includes authorization checks using JWT tokens and role validation.
  - Utilized `ResponseEntityBuilder` for consistent response formatting.

* **Refactoring and dependency injection**:
  - Replaced `@Autowired` with constructor-based dependency injection for `DBusService`, and added new dependencies (`JwtService` and `UserServiceImpl`) to the constructor. This improves testability and aligns with best practices.

### Changes to `BankAccountRepository`:

* **Code cleanup**:
  - Removed an unused method (`findByUserAndDefaultTrue`) and retained the relevant method (`findByUserAndIsDefaultTrue`) for retrieving the default bank account of a user. This simplifies the repository interface.