### PR TITLE
Rashmi/development v2

### DIFF
--- a/src/main/java/com/canpay/api/config/MqttConfig.java
+++ b/src/main/java/com/canpay/api/config/MqttConfig.java
@@ -1,0 +1,29 @@
+package com.canpay.api.config;
+
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MqttConfig {
+    private static final Logger logger = LoggerFactory.getLogger(MqttConfig.class);
+
+    @Bean
+    public MqttClient mqttClient() throws MqttException {
+//        String brokerUrl = "tcp://localhost:1883";
+//        String brokerUrl = "mqtt-v1-canpay.sehanw.com";
+        String brokerUrl = "tcp://mqtt-v1-canpay.sehanw.com:1883";
+        String clientId = "backend_" + System.currentTimeMillis();
+        MqttClient client = new MqttClient(brokerUrl, clientId);
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setAutomaticReconnect(true);
+        options.setCleanSession(false);
+        client.connect(options);
+        logger.info("Connected to MQTT broker: {}", brokerUrl);
+        return client;
+    }
+}

--- a/src/main/java/com/canpay/api/controller/account/OperatorAssignmentControllerAc.java
+++ b/src/main/java/com/canpay/api/controller/account/OperatorAssignmentControllerAc.java
@@ -1,0 +1,93 @@
+package com.canpay.api.controller.account;
+
+import com.canpay.api.dto.dashboard.operatorassignment.OperatorAssignmentResponseDto;
+import com.canpay.api.entity.OperatorAssignment;
+import com.canpay.api.repository.OperatorAssignmentRepository;
+import com.canpay.api.service.implementation.JwtService;
+import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.UUID;
+
+
+@RestController
+@RequestMapping("/api/v1/operator")
+public class OperatorAssignmentControllerAc {
+
+    private final Logger logger = org.slf4j.LoggerFactory.getLogger(OperatorAssignmentControllerAc.class);
+
+    private final OperatorAssignmentRepository operatorAssignmentRepository;
+    private final JwtService jwtService;
+
+    public OperatorAssignmentControllerAc(OperatorAssignmentRepository operatorAssignmentRepository, JwtService jwtService) {
+        this.operatorAssignmentRepository = operatorAssignmentRepository;
+        this.jwtService = jwtService;
+    }
+
+    @GetMapping("/assignment-status/{operatorId}")
+    @PreAuthorize("hasRole('OPERATOR')")
+    public ResponseEntity<?> getAssignmentStatus(@PathVariable String operatorId,  @RequestHeader(value = "Authorization") String authHeader) {
+
+        logger.info("Received request to get assignment status for operatorId: {}", operatorId);
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            logger.warn("Authorization header missing or invalid");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("success", false, "message", "Authorization header with Bearer token is required"));
+        }
+
+        String token = authHeader.substring(7);
+
+        try {
+            String tokenRole = jwtService.extractRole(token);
+            if (!"OPERATOR".equals(tokenRole)) {
+                logger.warn("Invalid role in token: {}", tokenRole);
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(Map.of("success", false, "message", "Invalid role for operator assignment check"));
+            }
+        } catch (Exception e) {
+            logger.warn("Invalid token: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("success", false, "message", "Invalid or expired token"));
+        }
+
+        UUID operatorUUId;
+        try {
+            operatorUUId = UUID.fromString(operatorId);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("success", false, "message", "Invalid bus ID format: " + operatorId));
+        }
+
+        OperatorAssignment assignment = operatorAssignmentRepository
+                .findFirstByOperatorIdOrderByAssignedAtDesc(operatorUUId);
+
+        OperatorAssignmentResponseDto responseDto = new OperatorAssignmentResponseDto();
+
+        if (assignment == null) {
+            responseDto.setAssigned(false);
+            responseDto.setStatus(null);
+            responseDto.setBus(null);
+            responseDto.setAssignedAt(null);
+            return ResponseEntity.ok(responseDto);
+        }
+
+        boolean assigned = assignment.getStatus() == OperatorAssignment.AssignmentStatus.ACTIVE;
+        responseDto.setAssigned(assigned);
+        responseDto.setStatus(assignment.getStatus());
+        // You may need to map Bus and User to their respective DTOs
+        // For now, set only the bus id if you don't have a mapper
+        responseDto.setBusId(assignment.getBus().getId());
+        responseDto.setOperatorId(assignment.getOperator().getId());
+        responseDto.setAssignedAt(assignment.getAssignedAt());
+        responseDto.setId(assignment.getId());
+        responseDto.setCreatedAt(assignment.getCreatedAt());
+        responseDto.setUpdatedAt(assignment.getUpdatedAt());
+
+        logger.info("Assignment status for operatorId {}: {}", operatorId, responseDto);
+        return ResponseEntity.ok(responseDto);
+
+}}

--- a/src/main/java/com/canpay/api/dto/dashboard/operatorassignment/OperatorAssignmentResponseDto.java
+++ b/src/main/java/com/canpay/api/dto/dashboard/operatorassignment/OperatorAssignmentResponseDto.java
@@ -19,6 +19,7 @@ public class OperatorAssignmentResponseDto {
     private LocalDateTime assignedAt;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private boolean assigned; // Rashmi added
 
     public OperatorAssignmentResponseDto() {
     }
@@ -92,5 +93,13 @@ public class OperatorAssignmentResponseDto {
             this.operator = new UserDto();
         }
         this.operator.setId(operatorid);
+    }
+
+    public boolean isAssigned() {
+        return assigned;
+    }
+
+    public void setAssigned(boolean assigned) {
+        this.assigned = assigned;
     }
 }

--- a/src/main/java/com/canpay/api/repository/OperatorAssignmentRepository.java
+++ b/src/main/java/com/canpay/api/repository/OperatorAssignmentRepository.java
@@ -13,4 +13,6 @@ import java.util.UUID;
 public interface OperatorAssignmentRepository extends JpaRepository<OperatorAssignment, UUID> {
     Optional<OperatorAssignment> findByOperatorAndBus(User operator, Bus bus);
     Optional<OperatorAssignment> findByBusIdAndOperatorIdAndStatus(UUID busId, UUID operatorId, OperatorAssignment.AssignmentStatus status);
+    OperatorAssignment findFirstByOperatorIdOrderByAssignedAtDesc(UUID operatorId);
+
 }


### PR DESCRIPTION
This pull request introduces MQTT integration for real-time messaging, adds a new controller for operator assignment status, and enhances the `OperatorAssignmentResponseDto` class. The changes focus on enabling MQTT communication, implementing a new endpoint for operator assignment status, and improving the data model for operator assignments.

### MQTT Integration:
* Introduced `MqttConfig` to configure and initialize an MQTT client for the application. The client connects to the broker at `tcp://mqtt-v1-canpay.sehanw.com:1883` with automatic reconnect and persistent session enabled (`src/main/java/com/canpay/api/config/MqttConfig.java`).
* Updated `PaymentController` to use the MQTT client for publishing payment notifications to a topic specific to each bus. Notifications include transaction details in JSON format (`src/main/java/com/canpay/api/controller/account/PaymentController.java`).

### New Controller for Operator Assignment:
* Added `OperatorAssignmentControllerAc` to handle requests related to operator assignment status. This includes validating JWT tokens, extracting roles, and fetching the latest assignment status for an operator (`src/main/java/com/canpay/api/controller/account/OperatorAssignmentControllerAc.java`).

### Enhancements to Data Model:
* Enhanced `OperatorAssignmentResponseDto` by adding a new `assigned` field to indicate whether an operator is currently assigned. Getter and setter methods were added for this field (`src/main/java/com/canpay/api/dto/dashboard/operatorassignment/OperatorAssignmentResponseDto.java`). [[1]](diffhunk://#diff-c78d36dcb74ed88d09d5f9205739418911b1f91067c6ec328549cad9dd7fbd4bR22) [[2]](diffhunk://#diff-c78d36dcb74ed88d09d5f9205739418911b1f91067c6ec328549cad9dd7fbd4bR97-R104)
* Extended `OperatorAssignmentRepository` with a method to fetch the most recent assignment for a given operator (`src/main/java/com/canpay/api/repository/OperatorAssignmentRepository.java`).