### PR TITLE
canpay: get recent transactions by passengerID

### DIFF
--- a/src/main/java/com/canpay/api/controller/account/TransactionController.java
+++ b/src/main/java/com/canpay/api/controller/account/TransactionController.java
@@ -30,9 +30,9 @@ public class TransactionController {
         this.jwtService = jwtService;
     }
 
-    @GetMapping("/recent")
+    @GetMapping("/recent/{passengerId}")
     @PreAuthorize("hasRole('PASSENGER')")
-    public ResponseEntity<?> getRecentTransactions(@RequestHeader(value = "Authorization") String authHeader) {
+    public ResponseEntity<?> getRecentTransactions(@RequestHeader(value = "Authorization") String authHeader, @PathVariable UUID passengerId) {
         logger.debug("Received request for recent transactions");
 
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
@@ -58,7 +58,7 @@ public class TransactionController {
         }
 
         try {
-            List<Transaction> transactions = transactionService.getRecentTransactions(passengerEmail);
+            List<Transaction> transactions = transactionService.getRecentTransactions(passengerId);
             List<Map<String, Object>> transactionData = transactions.stream().map(t -> {
                 Map<String, Object> data = new HashMap<>();
                 data.put("transactionId", t.getId().toString());

--- a/src/main/java/com/canpay/api/service/implementation/TransactionService.java
+++ b/src/main/java/com/canpay/api/service/implementation/TransactionService.java
@@ -24,14 +24,14 @@ public class TransactionService {
         this.userRepository = userRepository;
     }
 
-    public List<Transaction> getRecentTransactions(String passengerEmail) {
-        User passenger = userRepository.findByEmail(passengerEmail)
+    public List<Transaction> getRecentTransactions(UUID passengerID) {
+        User passenger = userRepository.findById(passengerID)
                 .orElseThrow(() -> {
-                    logger.warn("Passenger not found: {}", passengerEmail);
+                    logger.warn("Passenger not found: {}", passengerID);
                     return new RuntimeException("Passenger not found");
                 });
         List<Transaction> transactions = transactionRepository.findTop10ByPassengerOrderByHappenedAtDesc(passenger);
-        logger.info("Fetched {} recent transactions for passenger: {}", transactions.size(), passengerEmail);
+        logger.info("Fetched {} recent transactions for passenger: {}", transactions.size(), passengerID);
         return transactions;
     }
 


### PR DESCRIPTION
This pull request updates the `TransactionController` and `TransactionService` classes to replace the use of a passenger's email with their unique ID (`UUID`) for fetching recent transactions. This change improves the accuracy and security of passenger identification.

### Changes in `TransactionController`:

* Updated the `@GetMapping` annotation for the `getRecentTransactions` endpoint to include a `passengerId` path variable. (`src/main/java/com/canpay/api/controller/account/TransactionController.java`, [src/main/java/com/canpay/api/controller/account/TransactionController.javaL33-R35](diffhunk://#diff-66f801af7c73a164097cdfad96353daaa5827924aad28901724f99be694bf5c0L33-R35))
* Modified the `getRecentTransactions` method to accept a `passengerId` parameter instead of deriving the passenger's email from the authorization header. (`src/main/java/com/canpay/api/controller/account/TransactionController.java`, [src/main/java/com/canpay/api/controller/account/TransactionController.javaL33-R35](diffhunk://#diff-66f801af7c73a164097cdfad96353daaa5827924aad28901724f99be694bf5c0L33-R35))

### Changes in `TransactionService`:

* Refactored the `getRecentTransactions` method to use `UUID passengerID` instead of `String passengerEmail` for identifying passengers. This includes updating the repository query to find passengers by ID and logging changes to reflect the new identifier. (`src/main/java/com/canpay/api/service/implementation/TransactionService.java`, [src/main/java/com/canpay/api/service/implementation/TransactionService.javaL27-R34](diffhunk://#diff-5deeb98a22d7e32092d5d601e9b06fc1473202d7599f98748e9b9096c64fcea3L27-R34))