### PR TITLE
CanPay: hashing the payment

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,11 +42,6 @@ fromName=${FROM_NAME:CanPay}
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${CLERK_ISSUER_URI}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${CLERK_JWKS_URI}
 
-#mqtt.broker.url=tcp://46.62.128.3:1883
-#mqtt.client.id=canpay-backend-client-${random.uuid}
-#onesignal.app.id=${ONESIGNAL_APP_ID}
-#onesignal.api.key=${ONESIGNAL_API_KEY}
-#
 mqtt.broker=${MQTT_BROKER}
 mqtt.client-id=${MQTT_CLIENT_ID}
 mqtt.username=${MQTT_USERNAME}
@@ -58,3 +53,6 @@ spring.web.resources.static-locations=classpath:/static/
 spring.mvc.static-path-pattern=/**
 spring.resources.add-mappings=true
 spring.web.resources.cache.period=3600
+
+canpay.hmac.passenger-secret=${CANPAY_HMAC_PASSENGER_SECRET}
+


### PR DESCRIPTION
This pull request introduces HMAC signature verification for passenger payment requests in the `PaymentController`, enhancing security by ensuring requests are authenticated with a shared secret. The main changes include extracting and validating new headers, verifying the HMAC signature, and updating configuration to support this feature.

**Security: HMAC Signature Verification**
* Added extraction of `X-Signature` and `X-Timestamp` headers in the `processPayment` endpoint, and implemented logic to verify the HMAC signature using a shared secret before processing payment requests. If the signature is missing or invalid, the request is rejected. [[1]](diffhunk://#diff-21ca681c2e428b91bd718d5ac0acebb5e41ab09c33c6f1dc88f5844edc49a5eaL60-R69) [[2]](diffhunk://#diff-21ca681c2e428b91bd718d5ac0acebb5e41ab09c33c6f1dc88f5844edc49a5eaR78-R87) [[3]](diffhunk://#diff-21ca681c2e428b91bd718d5ac0acebb5e41ab09c33c6f1dc88f5844edc49a5eaR96-R141)
* Introduced `computeHmacSha256Base64` utility method for signature calculation, and a `getHmacSecretForPassenger` method to retrieve the shared secret.

**Configuration**
* Injected the passenger HMAC secret via the new `canpay.hmac.passenger-secret` property in `application.properties`, which is populated from the environment variable `CANPAY_HMAC_PASSENGER_SECRET`. [[1]](diffhunk://#diff-21ca681c2e428b91bd718d5ac0acebb5e41ab09c33c6f1dc88f5844edc49a5eaR19) [[2]](diffhunk://#diff-21ca681c2e428b91bd718d5ac0acebb5e41ab09c33c6f1dc88f5844edc49a5eaR36-R38) [[3]](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R56-R58)

**Minor Cleanups**
* Adjusted the location of passenger user fetching to align with the new HMAC verification flow. [[1]](diffhunk://#diff-21ca681c2e428b91bd718d5ac0acebb5e41ab09c33c6f1dc88f5844edc49a5eaR96-R141) [[2]](diffhunk://#diff-21ca681c2e428b91bd718d5ac0acebb5e41ab09c33c6f1dc88f5844edc49a5eaL109-R160)
* Removed commented-out configuration lines for clarity in `application.properties`.