### PR TITLE
CanPay: app prop

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,7 +19,9 @@ spring.jpa.database-platform=${SPRING_JPA_DATABASE_PLATFORM}
 application.jwt.secret-key=${APPLICATION_JWT_SECRET_KEY}
 application.jwt.token-prefix=${APPLICATION_JWT_TOKEN_PREFIX}
 #application.jwt.token-expiration-after-days=${APPLICATION_JWT_TOKEN_EXPIRATION_AFTER_DAYS}
-application.jwt.tokenExpirationAfterMinutes=1000
+#application.jwt.tokenExpirationAfterMinutes=1000
+application.jwt.tokenExpirationAfterMinutes= ${APPLICATION_JWT_TOKEN_EXPIRATION_AFTER_DAYS}
+
 
 application.jwt.public-key-base64=${JWT_PUBLIC_KEY_BASE64}
 application.jwt.private-key-base64=${JWT_PRIVATE_KEY_BASE64}
@@ -56,3 +58,5 @@ spring.web.resources.cache.period=3600
 
 canpay.hmac.passenger-secret=${CANPAY_HMAC_PASSENGER_SECRET}
 
+onesignal.app-id=your-onesignal-app-id
+onesignal.api-key=your-rest-api-key


### PR DESCRIPTION
This pull request updates the `application.properties` configuration to improve flexibility and add new integration settings. The most significant changes are related to JWT token expiration configuration and the addition of OneSignal integration properties.

**JWT Token Expiration Configuration:**
* Changed `application.jwt.tokenExpirationAfterMinutes` to be set via the `APPLICATION_JWT_TOKEN_EXPIRATION_AFTER_DAYS` environment variable, allowing for more dynamic configuration. The previous hardcoded value is now commented out.

**OneSignal Integration:**
* Added `onesignal.app-id` and `onesignal.api-key` properties to support OneSignal integration for notifications.